### PR TITLE
Verdana spacing

### DIFF
--- a/birch-artifact-grid-item.css
+++ b/birch-artifact-grid-item.css
@@ -21,7 +21,6 @@
 .title {
   border-top: 1px solid #CFD6D7;
   display:block;
-  font-size:14px;
   font-size:0.875rem;
   height: 28px;
   line-height: 1.3;

--- a/birch-artifact-grid-item.css
+++ b/birch-artifact-grid-item.css
@@ -23,10 +23,10 @@
   display:block;
   font-size:14px;
   font-size:0.875rem;
-  height: 25px;
-  line-height: 1.2;
+  height: 28px;
+  line-height: 1.3;
   overflow:hidden;
-  padding: 4px 3px 4px;
+  padding: 2px 3px 4px;
   position:relative;
   text-align:center;
   text-overflow: ellipsis;


### PR DESCRIPTION
### Changes

- The spacing is not consistent across browsers and the bottom and top of the font come really close on different lines. I increased the line-height to make up for this and the browser variations. 
- I removed the 14 px font-size because now with Verdana 0.875 is closer to the old 12px font. 
- I shrunk the top margin a bit to make up for the increase in height.

@liechtym / @jpodwys  / @jasonallen68 