### PR TITLE
Pass cis

### DIFF
--- a/birch-artifact-grid-item.html
+++ b/birch-artifact-grid-item.html
@@ -448,7 +448,7 @@
     _openContactCard: function(e) {
       e.stopPropagation();
       this.fire('gallery-close-contact-card',{});
-      var contactData = {'event': e, 'data': this.data.ftUserInfo }
+      var contactData = {'event': e, 'cisId': this.data.contributorCisUserId }
       this.fire('gallery-open-contact-card', contactData);
     },
     _translateContributor: function(val) {

--- a/birch-artifact-grid-item.html
+++ b/birch-artifact-grid-item.html
@@ -68,8 +68,8 @@
                   <i class='add-icon'></i><wc-i18n key='birch-artifact-grid-item.add_title'></wc-i18n>
                 </a>
               </div>
-              <div class="contributor" title='[[data.ftUserInfo.contactName]]'>
-                <span>[[_translateContributor(_contributedBy)]]</span><span class='contributor-name' on-tap='_openContactCard'>[[data.ftUserInfo.contactName]]</span>
+              <div class="contributor" title='[[_getContactName(data)]]'>
+                <span>[[_translateContributor(_contributedBy)]]</span><span class='contributor-name' on-tap='_openContactCard'>[[_getContactName(data)]]</span>
               </div>
             </div>
           </template> 
@@ -468,6 +468,9 @@
     _isOwner: function(ex, user, owner, restricted) {
       if (!restricted || !ex) return false;
       return (user === owner);
+    },
+    _getContactName: function(data) {
+      return data.contributorContactName || data.ftUserInfo.contactName
     }
   });
 })();

--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "birch-artifact-grid-item",
-  "version": "1.6.5",
+  "version": "1.6.6",
   "authors": [
     "Josh Crowther <jshcrowthe@gmail.com>"
   ],


### PR DESCRIPTION
### Summary
We will soon be using MPS instead of Memories AMI to get the contributor contact name. These changes prepare us to use this new endpoint.

### Changes
- The new endpoint will send the data back in a flattened format so `_getContactName` allows for this.
- When the user clicks on the contributor name, pass the cis id to for the `birch-contact-card` to consume
- Updated bower version
