### PR TITLE
Change add to album to return an object instead of array

### DIFF
--- a/birch-artifact-grid-item-preview.html
+++ b/birch-artifact-grid-item-preview.html
@@ -134,7 +134,7 @@
           this._handleUploadError(result.err);
           return;
         }
-        var artifact = (Array.isArray(result)) ? result[0] : result.artifact;
+        var artifact = (Array.isArray(result.items)) ? result.items[0] : result.artifact;
         var thumbSquareUrl = result.artifact ? result.artifact.thumbSquareUrl : null;
         artifact.thumbSquareUrl = this.data.thumbSquareUrl || thumbSquareUrl;
         if(!this.data.thumbSquareUrl){

--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "birch-artifact-grid-item",
-  "version": "1.6.12",
+  "version": "1.6.13",
   "authors": [
     "Josh Crowther <jshcrowthe@gmail.com>"
   ],


### PR DESCRIPTION
### Changes
- Changing the data structure returned by `_execAddToAlbum` to be an array wrapped in an object instead of just returning an array.  This is being done to fix a bug that occurs when the `noAlbumSort` and `actionsMenuEx` experiments are both turned on.

@jpodwys / @chadeddington / @dcravenus 